### PR TITLE
Local dev environment fixes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,6 @@
 				"ioredis": "^5.3.2",
 				"joi": "^17.11.0",
 				"jsonwebtoken": "^9.0.2",
-				"module-alias": "^2.2.3",
 				"node-cron": "^3.0.3",
 				"uuid": "^9.0.1",
 				"winston": "^3.11.0",
@@ -42,6 +41,7 @@
 				"jest": "^29.7.0",
 				"nodemon": "^3.0.2",
 				"ts-jest": "^29.1.1",
+				"tsc-alias": "^1.8.8",
 				"tsx": "^4.6.2",
 				"typescript": "^5.3.3"
 			},
@@ -3142,6 +3142,15 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
+			}
+		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -6069,12 +6078,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/module-alias": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
-			"integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
-			"license": "MIT"
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6110,6 +6113,19 @@
 				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
 				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
 				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+			}
+		},
+		"node_modules/mylas": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+			"integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/raouldeheer"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -6612,6 +6628,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/plimit-lit": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+			"integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+			"dev": true,
+			"dependencies": {
+				"queue-lit": "^1.5.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6730,6 +6758,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/queue-lit": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+			"integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -7661,6 +7698,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tsc-alias": {
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+			"integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.3",
+				"commander": "^9.0.0",
+				"get-tsconfig": "^4.10.0",
+				"globby": "^11.0.4",
+				"mylas": "^2.1.9",
+				"normalize-path": "^3.0.0",
+				"plimit-lit": "^1.2.6"
+			},
+			"bin": {
+				"tsc-alias": "dist/bin/index.js"
+			},
+			"engines": {
+				"node": ">=16.20.2"
 			}
 		},
 		"node_modules/tslib": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"dev": "tsx watch src/index.ts",
-		"build": "tsc",
+		"build": "tsc && tsc-alias",
 		"start": "node dist/index.js",
 		"test": "jest",
 		"test:watch": "jest --watch",
@@ -43,8 +43,7 @@
 		"uuid": "^9.0.1",
 		"ws": "^8.14.2",
 		"jsonwebtoken": "^9.0.2",
-		"bcryptjs": "^2.4.3",
-		"module-alias": "^2.2.3"
+		"bcryptjs": "^2.4.3"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.21",
@@ -63,12 +62,10 @@
 		"ts-jest": "^29.1.1",
 		"tsx": "^4.6.2",
 		"typescript": "^5.3.3",
-		"nodemon": "^3.0.2"
+		"nodemon": "^3.0.2",
+		"tsc-alias": "^1.8.8"
 	},
 	"engines": {
 		"node": ">=18.0.0"
-	},
-	"_moduleAliases": {
-		"@": "dist"
 	}
 }

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,4 +1,3 @@
-import "module-alias/register";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -37,7 +37,6 @@
 				"jest": "^29.7.0",
 				"ts-jest": "^29.1.1",
 				"tsc-alias": "^1.8.8",
-				"tsconfig-paths": "^4.2.0",
 				"tsx": "^4.6.2",
 				"typescript": "^5.3.3"
 			},
@@ -5932,15 +5931,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7475,29 +7465,6 @@
 			},
 			"engines": {
 				"node": ">=16.20.2"
-			}
-		},
-		"node_modules/tsconfig-paths": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-			"integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-			"dev": true,
-			"dependencies": {
-				"json5": "^2.2.2",
-				"minimist": "^1.2.6",
-				"strip-bom": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/tsconfig-paths/node_modules/strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/tslib": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,7 +18,6 @@
 				"helmet": "^7.1.0",
 				"ioredis": "^5.3.2",
 				"joi": "^17.11.0",
-				"module-alias": "^2.2.3",
 				"node-cron": "^3.0.3",
 				"uuid": "^9.0.1",
 				"winston": "^3.11.0",
@@ -37,6 +36,8 @@
 				"eslint": "^8.54.0",
 				"jest": "^29.7.0",
 				"ts-jest": "^29.1.1",
+				"tsc-alias": "^1.8.8",
+				"tsconfig-paths": "^4.2.0",
 				"tsx": "^4.6.2",
 				"typescript": "^5.3.3"
 			},
@@ -2661,6 +2662,18 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/body-parser": {
 			"version": "1.20.3",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -2908,6 +2921,42 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3047,6 +3096,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/compressible": {
@@ -4579,6 +4637,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -5862,11 +5932,14 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/module-alias": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
-			"integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
-			"license": "MIT"
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
@@ -5903,6 +5976,19 @@
 				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
 				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
 				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+			}
+		},
+		"node_modules/mylas": {
+			"version": "2.1.13",
+			"resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+			"integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/raouldeheer"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -6329,6 +6415,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/plimit-lit": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+			"integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+			"dev": true,
+			"dependencies": {
+				"queue-lit": "^1.5.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6442,6 +6540,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/queue-lit": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+			"integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6506,6 +6613,18 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
 			}
 		},
 		"node_modules/redis-errors": {
@@ -7335,6 +7454,50 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tsc-alias": {
+			"version": "1.8.16",
+			"resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+			"integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.3",
+				"commander": "^9.0.0",
+				"get-tsconfig": "^4.10.0",
+				"globby": "^11.0.4",
+				"mylas": "^2.1.9",
+				"normalize-path": "^3.0.0",
+				"plimit-lit": "^1.2.6"
+			},
+			"bin": {
+				"tsc-alias": "dist/bin/index.js"
+			},
+			"engines": {
+				"node": ">=16.20.2"
+			}
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+			"integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+			"dev": true,
+			"dependencies": {
+				"json5": "^2.2.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tsconfig-paths/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/tslib": {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"dev": "tsx watch src/index.ts",
-		"build": "tsc",
+		"build": "tsc && tsc-alias",
 		"start": "node dist/index.js",
 		"test": "jest",
 		"test:watch": "jest --watch",
@@ -41,8 +41,7 @@
 		"axios": "^1.6.2",
 		"winston": "^3.11.0",
 		"uuid": "^9.0.1",
-		"ws": "^8.14.2",
-		"module-alias": "^2.2.3"
+		"ws": "^8.14.2"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.21",
@@ -58,12 +57,11 @@
 		"jest": "^29.7.0",
 		"ts-jest": "^29.1.1",
 		"tsx": "^4.6.2",
-		"typescript": "^5.3.3"
+		"typescript": "^5.3.3",
+		"tsconfig-paths": "^4.2.0",
+		"tsc-alias": "^1.8.8"
 	},
 	"engines": {
 		"node": ">=18.0.0"
-	},
-	"_moduleAliases": {
-		"@": "dist"
 	}
 }

--- a/server/package.json
+++ b/server/package.json
@@ -58,7 +58,6 @@
 		"ts-jest": "^29.1.1",
 		"tsx": "^4.6.2",
 		"typescript": "^5.3.3",
-		"tsconfig-paths": "^4.2.0",
 		"tsc-alias": "^1.8.8"
 	},
 	"engines": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,3 @@
-import "module-alias/register";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";


### PR DESCRIPTION
Replaces `module-alias` with `tsc-alias` which integrates much better with `tsc` and can handle `@/file` referencing both `src` and `dist` depending on dev vs build.


<img width="1047" height="866" alt="image" src="https://github.com/user-attachments/assets/5af6c924-021e-40d8-abe5-19ea3a63a01e" />
